### PR TITLE
Fix source imports with ~

### DIFF
--- a/hyprparser/src/classes/parser.py
+++ b/hyprparser/src/classes/parser.py
@@ -413,7 +413,7 @@ class DataParser:
     @staticmethod
     def parse_source(line: str) -> None:
         _, path = line.split(" = ")
-
+        path = os.path.expanduser(path)
         content = Helper.read_file(path)
 
         HyprData.files.append(File(path, content))


### PR DESCRIPTION
Fix imports that use the ~ to set the user home path.
For example
```hyprlang
source=~/.config/hypr/monitors.conf
source=~/.config/hypr/variables.conf
source=~/.config/hypr/colors.conf
```
were not parsed correctly